### PR TITLE
HTML capabilities + twitch chat URL update

### DIFF
--- a/rofi-twitch
+++ b/rofi-twitch
@@ -26,8 +26,8 @@ case "${2:-b}" in
         exit 1
         ;;
 esac
-
-[ -z "$channel" ] && channel=$(twitchnotifier -c $user -n | rofi \
+[ -z "$channel" ] && channel=$(twitchnotifier -c $user -n | perl \
+    -MHTML::Entities -pe 'encode_entities($_);' | rofi \
     -theme-str '#window { width: 1000; }' -dmenu -markup-rows -i \
     -p "" | grep -Po '^.+?(?=\:)')
 [ -z "$channel" ] && exit
@@ -39,5 +39,6 @@ streamlink https://twitch.tv/$channel $quality &
 # just add a "&" at the end of the streamlink line and uncomment
 # the lines below:
 
-# browser=firefox-nightly
-# $browser --new-window $twitch$channel/chat?popout= &
+# browser=firefox
+# channel="$(echo $channel | tr -d ' ')"
+# $browser --new-window "https://twitch.tv/popout/$channel/chat"


### PR DESCRIPTION
Rofi couldn't escape characters like ampersands, resulting into a blank line when trying to display the followed channels. I added an HTML encode module using perl.

I also updated the twitch chat bloc with the new URL, making sure the web page loaded doesn't contain any blank spaces.